### PR TITLE
Allow components to fail gracefully

### DIFF
--- a/hab/aggregator/aggregator.cpp
+++ b/hab/aggregator/aggregator.cpp
@@ -25,7 +25,7 @@ public:
   {
     sleep(1);
     std::string payload = serialize(data);
-    std::cout << "Sending data: " << payload << std::endl;
+    //std::cout << "Sending data: " << payload << std::endl;
     sendPayload(payload, destination);
   }
 

--- a/hab/boom/boom.cpp
+++ b/hab/boom/boom.cpp
@@ -23,7 +23,7 @@ public:
       auto payload(((SpaString*)message)->st);
       if (isDeploy(payload))
       {
-        std::cout << "DEPLOYING!\n";
+        //std::cout << "DEPLOYING!\n";
         curMessage = "DEPLOYING BOOM";
         curMessage = "BOOM DEPLOYED";
       }
@@ -33,7 +33,7 @@ public:
       float payload = ((SpaData<float>*)message)->payload;
       if (inRange(payload))
       {
-        std::cout << "DEPLOYING!\n";
+        //std::cout << "DEPLOYING!\n";
         curMessage = "DEPLOYING BOOM";
         curMessage = "BOOM DEPLOYED";
       } 
@@ -44,7 +44,7 @@ public:
   {
     sleep(1);
     std::string payload = curMessage;
-    std::cout << "Sending payload: " << payload << std::endl;
+    //std::cout << "Sending payload: " << payload << std::endl;
     sendPayload(payload, destination);
   }
 

--- a/hab/camera/camera.cpp
+++ b/hab/camera/camera.cpp
@@ -19,7 +19,7 @@ public:
     auto castMessage = (SpaString*)message;
     std::string payload(castMessage->st);
 
-    std::cout << "Payload: " << payload << std::endl;
+    //std::cout << "Payload: " << payload << std::endl;
   }
 
   void sendData(LogicalAddress destination)
@@ -27,7 +27,7 @@ public:
     sleep(1);
     // TODO Write me!
     std::string payload = "yo foo I took a photo";
-    std::cout << "Sending payload: " << payload << std::endl;
+    //std::cout << "Sending payload: " << payload << std::endl;
     sendPayload(payload, destination);
   }
 

--- a/hab/digital-temp/py_component.py
+++ b/hab/digital-temp/py_component.py
@@ -9,7 +9,6 @@ def handleSpaData():
 
 def sendData():
     global i
-    print "YEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
     i += 1.0
     return 7.0 + i
     """

--- a/hab/digital-temp/temp.cpp
+++ b/hab/digital-temp/temp.cpp
@@ -51,7 +51,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
 
     pFunc = PyDict_GetItemString(pDict, "sendData");
   }

--- a/hab/filter/filter.cpp
+++ b/hab/filter/filter.cpp
@@ -27,7 +27,7 @@ public:
     auto castMessage = (SpaData<float>*)message;
     float payload = castMessage->payload;
 
-    std::cout << "Payload: " << payload << std::endl;
+    //std::cout << "Payload: " << payload << std::endl;
 
     filter.push(payload);
   }

--- a/hab/gyro/gyro.cpp
+++ b/hab/gyro/gyro.cpp
@@ -48,8 +48,7 @@ public:
 
     std::string payload(cStr);
 
-    std::cout << "Sending SpaData: " << payload << std::endl;
-
+    //std::cout << "Sending SpaData: " << payload << std::endl; 
     sendPayload(payload, destination);
   }
 
@@ -76,7 +75,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
   }
 };
 

--- a/hab/gyro/py_component.py
+++ b/hab/gyro/py_component.py
@@ -1,5 +1,6 @@
 print 'Initializing gyro...'
 
+
 #from Adafruit_Python_BNO055 import BNO055
 
 #the RST Pin on the Gyroscope.

--- a/hab/light-external/light.cpp
+++ b/hab/light-external/light.cpp
@@ -51,7 +51,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
 
     pFunc = PyDict_GetItemString(pDict, "sendData");
   }

--- a/hab/light-internal/light.cpp
+++ b/hab/light-internal/light.cpp
@@ -51,7 +51,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
 
     pFunc = PyDict_GetItemString(pDict, "sendData");
   }

--- a/hab/rtc/rtc.cpp
+++ b/hab/rtc/rtc.cpp
@@ -48,7 +48,7 @@ public:
 
     std::string payload(cStr);
 
-    std::cout << "Sending SpaData: " << payload << std::endl;
+    //std::cout << "Sending SpaData: " << payload << std::endl;
 
     sendPayload(payload, destination);
   }
@@ -76,7 +76,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
   }
 };
 

--- a/hab/subnetmanager/subnet_manager_driver.cpp
+++ b/hab/subnetmanager/subnet_manager_driver.cpp
@@ -19,7 +19,7 @@ int main(void)
   auto communicator = std::make_shared<LocalCommunicator>(&sock, routingTable, la_LSM);
 
   auto manager = std::make_shared<LocalSubnetManager>(communicator, routingTable, NUM_COMPONENTS, NUM_SUBSCRIPTIONS);
-  manager->listenMessages();
+  manager->start();
 
   return 0;
 }

--- a/hab/subnetmanager/subnet_manager_driver.cpp
+++ b/hab/subnetmanager/subnet_manager_driver.cpp
@@ -18,7 +18,7 @@ int main(void)
 
   auto communicator = std::make_shared<LocalCommunicator>(&sock, routingTable, la_LSM);
 
-  auto manager = std::make_shared<LocalSubnetManager>(communicator, routingTable, NUM_COMPONENTS, NUM_SUBSCRIPTIONS);
+  auto manager = std::make_shared<LocalSubnetManager>(communicator, routingTable, NUM_COMPONENTS, NUM_SUBSCRIPTIONS, la_LSM);
   manager->start();
 
   return 0;

--- a/hab/uvExternal/uvExternal.cpp
+++ b/hab/uvExternal/uvExternal.cpp
@@ -51,7 +51,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
 
     pFunc = PyDict_GetItemString(pDict, "sendData");
   }

--- a/hab/uvInternal/py_component.py
+++ b/hab/uvInternal/py_component.py
@@ -16,7 +16,6 @@ def handleSpaData():
 def sendData():
     global i
     i += 1.0
-    print "Returning",420.0 + i
     return (420.0 + i)
 
 def init():

--- a/hab/uvInternal/uvInternal.cpp
+++ b/hab/uvInternal/uvInternal.cpp
@@ -51,7 +51,7 @@ public:
 
     //not capturing result, should inits return anything?
     PyObject_CallFunction(pFunc, NULL);
-    std::cout << "py_component initialized" << std::endl;
+    //std::cout << "py_component initialized" << std::endl;
 
     dataFunc = PyDict_GetItemString(pDict, "sendData");
   }

--- a/lib/component.cpp
+++ b/lib/component.cpp
@@ -91,6 +91,7 @@ void Component::receiveMessage(SpaMessage* message)
     return;
 
   case op_SPA_SUBSCRIPTION_REPLY:
+    checkForSubscriptionFailure(message);
     return;
 
   case op_SPA_DATA:
@@ -106,6 +107,15 @@ void Component::receiveMessage(SpaMessage* message)
     return;
   }
 }
+
+void Component::checkForSubscriptionFailure(SpaMessage* message)
+{
+  if (message->spaHeader.source == subnetManagerAddress)
+  {
+    std::cout << "Subscription failed" << std::endl;
+  }
+}
+
 
 void Component::publish() //TODO find a better name
 {

--- a/lib/component.cpp
+++ b/lib/component.cpp
@@ -28,11 +28,11 @@ void Component::registerSubscriptionRequest(SpaMessage* message)
 
   if (addSubscriber(message->spaHeader.source, 0))
   {
-    std::cout << "Added " << message->spaHeader.source << " as a subscriber" << std::endl;
+    //std::cout << "Added " << message->spaHeader.source << " as a subscriber" << std::endl;
   }
   else
   {
-    std::cout << "Failed to add subscriber\n";
+    //std::cout << "Failed to add subscriber\n";
   }
 }
 

--- a/lib/component.hpp
+++ b/lib/component.hpp
@@ -230,6 +230,8 @@ public:
    */
   bool addSubscriber(LogicalAddress la, uint16_t d);
 
+  void checkForSubscriptionFailure(SpaMessage* message);
+
   void compSleep(int n);
 
   /*

--- a/lib/component.hpp
+++ b/lib/component.hpp
@@ -280,15 +280,15 @@ void component_start(LogicalAddress const& address)
   auto const comp = std::make_shared<T>(communicator);
 
   comp->registerWithSubnetManager();
-  std::cout << "Registered, waiting...\n";
+  //std::cout << "Registered, waiting...\n";
   comp->waitFor(op_ALL_REGISTERED);
-  std::cout << "Everyone is ready!...\n";
+  //std::cout << "Everyone is ready!...\n";
   comp->compSleep(2);
-  std::cout << "Initializing with init!\n";
+  //std::cout << "Initializing with init!\n";
   comp->init();
-  std::cout << "Initialized, waiting for okay...\n";
+  //std::cout << "Initialized, waiting for okay...\n";
   comp->waitFor(op_ALL_SUBSCRIBED);
-  std::cout << "Everyone is subscribed! Publishing and listening...\n";
+  //std::cout << "Everyone is subscribed! Publishing and listening...\n";
   comp->publish();
 }
 

--- a/lib/local_communicator.cpp
+++ b/lib/local_communicator.cpp
@@ -45,7 +45,7 @@ void LocalCommunicator::clientListen(std::function<void(cubiumClientSocket_t*)> 
   clientSocket_listen(clientSock, func, exitOp);
 }
 
-void LocalCommunicator::listen(std::function<void(cubiumServerSocket_t*)> messageHandler)
+void LocalCommunicator::listen(std::function<int(cubiumServerSocket_t*)> messageHandler)
 {
   if (serverSock == nullptr)
   {

--- a/lib/local_communicator.hpp
+++ b/lib/local_communicator.hpp
@@ -40,7 +40,7 @@ public:
 
   void clientListen(std::function<void(cubiumClientSocket_t*)>, uint8_t);
 
-  virtual void listen(std::function<void(cubiumServerSocket_t*)>);
+  virtual void listen(std::function<int(cubiumServerSocket_t*)>);
   virtual void listen(std::function<void(cubiumClientSocket_t*)>);
 
   void setServerSock(cubiumServerSocket_t* s) { serverSock = s; }

--- a/lib/local_subnet_manager.cpp
+++ b/lib/local_subnet_manager.cpp
@@ -20,12 +20,15 @@ void LSM_sendMessage(std::shared_ptr<LocalSubnetManager> const lsm, std::size_t 
   }
 }
 
-void LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSocket_t* sock)
+/* Return value indicates whether the LSM should continue listening.
+ * 0 = Keep listening
+ * 1 = Stop listening            */
+int LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSocket_t* sock)
 {
   if (lsm->routingTable->isEmpty())
   {
     std::cout << "Nothing in the routing table." << std::endl;
-    return;
+    return 0;
   }
 
   SpaMessage* msg = (SpaMessage*)sock->buf;
@@ -42,6 +45,7 @@ void LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSo
     if (lsm->allRegistered())
     {
       lsm->notifyComponents(op_ALL_REGISTERED);
+      return 1;
     }
   }
   break;
@@ -61,6 +65,7 @@ void LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSo
     if (lsm->allSubscribed())
     {
       lsm->notifyComponents(op_ALL_SUBSCRIBED);
+      return 1;
     }
   }
   break;
@@ -77,4 +82,6 @@ void LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSo
     std::cout << "Unrecognized SPA message:" << msg->spaHeader.opcode << std::endl;
     break;
   }
+
+  return 0;
 }

--- a/lib/local_subnet_manager.cpp
+++ b/lib/local_subnet_manager.cpp
@@ -45,7 +45,7 @@ int LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSoc
   {
     lsm->components.add(msg->spaHeader.source);
     lsm->routingTable->insert(msg->spaHeader.source, *sock);
-    lsm->communicator->printTable();
+    //lsm->communicator->printTable();
     LocalAck reply(0, 0, msg->spaHeader.source, LogicalAddress(1, 0), 0, 3500, 0);
     lsm->communicator->serverSend((SpaMessage*)&reply, sizeof(reply));
     if (lsm->allRegistered())
@@ -59,7 +59,7 @@ int LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSoc
   case op_SPA_SUBSCRIPTION_REQUEST:
   {
     lsm->disallowSubs();
-    std::cout << "Request" << std::endl;
+    //std::cout << "Request" << std::endl;
     if (lsm->routingTable->exists(msg->spaHeader.destination))
     {
       LSM_sendMessage(lsm, sizeof(SubscriptionRequest), msg);

--- a/lib/local_subnet_manager.hpp
+++ b/lib/local_subnet_manager.hpp
@@ -107,7 +107,7 @@ public:
     for(auto i = 0u; i < components.getSize(); ++i)
     {
       LogicalAddress dest = components.getAddress(i);
-      std::cout << "Sending message to :" << dest << "\n";
+      //std::cout << "Sending message to :" << dest << "\n";
       if (op == op_ALL_REGISTERED)
       {
         auto msg = AllRegistered(dest, LogicalAddress(1,0));
@@ -127,7 +127,7 @@ public:
   }
 
   bool allRegistered() { 
-    std::cout << "Components: " << components.getSize() << std::endl; 
+   // std::cout << "Components: " << components.getSize() << std::endl; 
     return components.getSize() == numComponents; }
 
   bool allSubscribed()

--- a/lib/local_subnet_manager.hpp
+++ b/lib/local_subnet_manager.hpp
@@ -21,7 +21,8 @@ int LSM_messageCallback(std::shared_ptr<LocalSubnetManager> lsm, cubiumServerSoc
 class LocalSubnetManager : public std::enable_shared_from_this<LocalSubnetManager>
 {
 public:
-  LocalSubnetManager(std::shared_ptr<LocalCommunicator> c, std::shared_ptr<RoutingTable<cubiumServerSocket_t>> rt, int n, int s)
+  LocalSubnetManager(std::shared_ptr<LocalCommunicator> c, std::shared_ptr<RoutingTable<cubiumServerSocket_t>> rt, int n, int s, LogicalAddress la)
+  : address(la)
   {
     communicator = c;
     routingTable = rt;
@@ -155,6 +156,8 @@ public:
   }
 
   void incrementSubs() { ++replyCount; }
+
+  LogicalAddress address;
 
 private:
   bool subsAllowed = true;

--- a/lib/local_subnet_manager.hpp
+++ b/lib/local_subnet_manager.hpp
@@ -60,7 +60,13 @@ public:
     }
   }
 
-  void doPhase(std::string const & phase)
+  enum Phase
+  {
+    INIT,
+    SUBSCRIBE
+  };
+
+  void doPhase(Phase phase)
   {
     bool timedOut = false;
     try 
@@ -69,13 +75,20 @@ public:
     }
     catch (std::runtime_error& e)
     {
-      std::cout << e.what() << "in " << phase << " phase" << std::endl;
+      std::cout << e.what();
       timedOut = true;
     }
 
-    if (!timedOut)
+    if (timedOut)
     {
-      std::cout << "Successful " << phase << " phase" << std::endl;
+      if (phase == Phase::INIT)
+      {
+        notifyComponents(op_ALL_REGISTERED);
+      }
+      else if (phase == Phase::SUBSCRIBE)
+      {
+        notifyComponents(op_ALL_SUBSCRIBED);
+      }
     }
 
     return;
@@ -83,8 +96,8 @@ public:
 
   void start()
   {
-    doPhase("init");
-    doPhase("subscribe");
+    doPhase(Phase::INIT);
+    doPhase(Phase::SUBSCRIBE);
     listenMessages();
   }
 

--- a/lib/logical_address.h
+++ b/lib/logical_address.h
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <stdint.h>
+#include <algorithm>
+
 
 /**
  * Logical Addresses are an abstraction for component addresses and interfaces.
@@ -20,6 +22,7 @@ struct LogicalAddress
    * @param compId the unique identifier for a component within a subnet
    */
   LogicalAddress(uint16_t const subId = 0, uint16_t const compId = 0) : subnetId(subId), componentId(compId) {}
+
   uint16_t const subnetId;
   uint16_t const componentId;
 };

--- a/lib/socket/clientSocket.cpp
+++ b/lib/socket/clientSocket.cpp
@@ -63,7 +63,7 @@ ssize_t clientSocket_requestDialogue(cubiumClientSocket_t* s,                   
   }
 
   uint8_t opcode = 0;
-  std::cout << "Getting called!\n";
+  //std::cout << "Getting called!\n";
   do
   { /* Send a new hello after every timeout until an ack is received */
 
@@ -75,8 +75,8 @@ ssize_t clientSocket_requestDialogue(cubiumClientSocket_t* s,                   
 
     recvfrom(s->sock, s->buf, 24, 0, (struct sockaddr*)&s->from, &s->length);
     opcode = ((SpaMessage*)s->buf)->spaHeader.opcode;
-    std::cout << "Got: " << int(opcode) << " from " << ((SpaMessage*)s->buf)->spaHeader.source << "\n";
-    std::cout << "Looking for: " << int(targetop) << "\n";
+    //std::cout << "Got: " << int(opcode) << " from " << ((SpaMessage*)s->buf)->spaHeader.source << "\n";
+    //std::cout << "Looking for: " << int(targetop) << "\n";
     if (opcode == op_SPA_SUBSCRIPTION_REQUEST && targetop == op_SPA_SUBSCRIPTION_REPLY)
     {
       func(s);
@@ -108,7 +108,7 @@ ssize_t clientSocket_send(const void* msg, size_t const len, cubiumClientSocket_
 
 void clientSocket_listen(cubiumClientSocket_t* s, std::function<void(cubiumClientSocket_t*)> const callback, uint8_t exitOp)
 {
-  if (exitOp != 0) { std::cout << "I'm waiting!" << std::endl;}
+  //if (exitOp != 0) { std::cout << "I'm waiting!" << std::endl;}
   /* Continually listen for messages and call the handler when one is received */
   for (;;)
   {

--- a/lib/socket/serverSocket.cpp
+++ b/lib/socket/serverSocket.cpp
@@ -40,7 +40,7 @@ cubiumServerSocket_t serverSocket_openSocket(uint16_t const port)
 }
 
 /* Listen through the given socket */
-void serverSocket_listen(cubiumServerSocket_t* s, std::function<void(cubiumServerSocket_t*)> const callback)
+void serverSocket_listen(cubiumServerSocket_t* s, std::function<int(cubiumServerSocket_t*)> const callback)
 {
   /* Continually listen for messages and call the handler when one is received */
   for (;;)
@@ -51,7 +51,10 @@ void serverSocket_listen(cubiumServerSocket_t* s, std::function<void(cubiumServe
       serverSocket_error("recvfrom failed");
     }
 
-    callback(s);
+    if (callback(s) != 0)
+    {
+      return;
+    }
   }
 }
 

--- a/lib/socket/serverSocket.hpp
+++ b/lib/socket/serverSocket.hpp
@@ -27,7 +27,7 @@ ssize_t serverSocket_send(const void* msg,        /* Message buffer */
 
 /* Start listening through a given socket*/
 void serverSocket_listen(cubiumServerSocket_t* port,                           /* Socket to listen through */
-                         std::function<void(cubiumServerSocket_t*)> const func /* Function called when a message is received */
+                         std::function<int(cubiumServerSocket_t*)> const func /* Function called when a message is received */
                          );
 
 /* Open a socket on the given port. Returns the socket info */


### PR DESCRIPTION
The subnet manager now has three listening phases:

- Initialization
- Subscription
- Normal operation

The callback function now has a return value so the LSM can know whether to keep listening or not. This allows us to introduce a timeout for how long the LSM will listen for initializations and subscriptions. This also makes the LSM notify components if their subscription has failed so that this can be handled on a component-to-component bases based on mission specifics.